### PR TITLE
fix error from missing @types/node-fetch

### DIFF
--- a/libs/express/service/aoc/package.json
+++ b/libs/express/service/aoc/package.json
@@ -7,5 +7,8 @@
     "lodash": "4.17.21",
     "node-fetch": "2.7.0",
     "tslib": "^2.3.0"
+  },
+  "devDependencies": {
+    "@types/node-fetch": "2.7.0"
   }
 }

--- a/libs/express/service/aoc/src/lib/aocService.ts
+++ b/libs/express/service/aoc/src/lib/aocService.ts
@@ -11,7 +11,7 @@ const { NX_AOC_URL, NX_AOC_SESSION } = process.env;
 export const fetchStarCounts = (year: number | never) =>
   typeof year !== 'number' || !hasDateOccured({ year, day: 1 })
     ? Promise.reject(Error('invalid date'))
-    : throttledFetch(`/${year}`, res => res.text().then(html => parseStarCounts(html).map(stars => ({ stars }))));
+    : throttledFetch(`/${year}`, res => (res.text() as Promise<string>).then(html => parseStarCounts(html).map(stars => ({ stars }))));
 
 export const fetchMainPuzzle = (year: number | never, day: number | never) =>
   typeof year !== 'number' || typeof day !== 'number' || !hasDateOccured({ year, day })


### PR DESCRIPTION
After I updated to your latest fix I got a TypeScript error
```
ERROR in ./libs/express/controller/calendar/src/lib/calendarController.ts:44:20
TS2339: Property 'map' does not exist on type 'unknown'.
    42 |             ? await fetchStarCounts(year).then(days =>
    43 |                 days
  > 44 |                   .map(({ stars }, index) => ({ [`days.${index}.stars`]: stars }))
       |                    ^^^
    45 |                   .reduce((prev, current) => ({ ...prev, ...current }), {}),
    46 |               )
    47 |             : {

```
and I found that TS doesn't know the type Response from node-fetch