### PR TITLE
Added countdown timer and auto puzzle unlock to react-app

### DIFF
--- a/libs/react/data-access/calendar/src/lib/calendarSlice.ts
+++ b/libs/react/data-access/calendar/src/lib/calendarSlice.ts
@@ -8,16 +8,20 @@ const calendar = 'calendar';
 export interface CalendarState {
   year: number;
   previousYear: number;
+  presentYear: number;
+  presentDay: number;
   starFetchRequests: { [year: number]: boolean };
 }
 
 const { year: loadedYear } = loadState(calendar);
-const { year: presentYear } = getPresentDate();
+const { year: presentYear, day: presentDay } = getPresentDate();
 const year = loadedYear ?? presentYear;
 
 const initialState: CalendarState = {
   year,
   previousYear: year,
+  presentYear,
+  presentDay,
   starFetchRequests: {},
 };
 
@@ -34,8 +38,13 @@ const calendarSlice = createSlice({
     endYearChange: state => {
       state.previousYear = state.year;
     },
+    updatePresentDate: state => {
+      const { year, day } = getPresentDate();
+      state.presentYear = year;
+      state.presentDay = day;
+    },
   },
 });
 
-export const { startYearChange, endYearChange } = calendarSlice.actions;
+export const { startYearChange, endYearChange, updatePresentDate } = calendarSlice.actions;
 export const calendarReducer = calendarSlice.reducer;

--- a/libs/react/feature/solver/src/lib/Solver.tsx
+++ b/libs/react/feature/solver/src/lib/Solver.tsx
@@ -7,7 +7,6 @@ import * as redux from '@aon/data-access-solver';
 import { useAppDispatch, useAppSelector } from '@aon/data-access-store';
 import { TitleDiv } from '@aon/ui-animations';
 import { Anchor, Banner } from '@aon/ui-components';
-import { getPresentDate } from '@aon/util-date';
 import { PuzzleElementNode, PuzzleNode } from '@aon/util-types';
 import * as S from './Solver.styled';
 
@@ -31,10 +30,10 @@ export const Solver: FC = props => {
 
 const SolverContainer: FC<{ incoming?: boolean }> = ({ incoming, ...restProps }) => {
   const { year } = useAppSelector(state => state.calendar);
-  const { day: presentDay, newDay, status } = useAppSelector(state => state.solver);
+  const { day: prevDay, newDay, status } = useAppSelector(state => state.solver);
 
-  const day = incoming ? newDay : presentDay;
-  const direction = presentDay < newDay ? 'left' : 'right';
+  const day = incoming ? newDay : prevDay;
+  const direction = prevDay < newDay ? 'left' : 'right';
   const { data } = api.useFetchCalendarQuery({ year });
   const { stars, title: puzzleTitle } = data?.days?.[day - 1] ?? {};
 
@@ -87,10 +86,8 @@ const SolverBody = ({ day }: { day: number }) => {
   );
 };
 
-const { day: presentDay, year: presentYear } = getPresentDate();
-
 const NavMenu = ({ day }: { day: number }) => {
-  const { year } = useAppSelector(state => state.calendar);
+  const { year, presentYear, presentDay } = useAppSelector(state => state.calendar);
   const dispatch = useAppDispatch();
   const highestDay = year === presentYear ? presentDay : 25;
   const aocLink = `${VITE_AOC_URL || 'https://adventofcode.com'}/${year}/day/${day}`;

--- a/libs/shared/util/date/src/index.ts
+++ b/libs/shared/util/date/src/index.ts
@@ -1,1 +1,1 @@
-export { getFirstYear, getPresentDate, hasDateOccured } from './lib/date';
+export * from './lib/date';

--- a/libs/shared/util/date/src/lib/date.spec.ts
+++ b/libs/shared/util/date/src/lib/date.spec.ts
@@ -1,4 +1,4 @@
-import { getFirstYear, getPresentDate, hasDateOccured, presentDate } from './date';
+import { getFirstYear, getPresentDate, hasDateOccured, timeUntilMidnight } from './date';
 
 describe('first year', () => {
   it('is correct', () => {
@@ -13,37 +13,48 @@ describe('current date', () => {
   describe('dates are correct', () => {
     it('before November in New York', () => {
       jest.setSystemTime(new Date(Date.UTC(2016, 10, 1)));
-      expect(presentDate()).toEqual({ year: 2015, day: 25 });
+      expect(getPresentDate()).toEqual({ year: 2015, day: 25 });
     });
     it('before December in New York', () => {
       jest.setSystemTime(new Date(Date.UTC(2016, 11, 1, 4)));
-      expect(presentDate()).toEqual({ year: 2016, day: 0 });
+      expect(getPresentDate()).toEqual({ year: 2016, day: 0 });
     });
     it('December 1st', () => {
       jest.setSystemTime(new Date(Date.UTC(2016, 11, 1, 5)));
-      expect(presentDate()).toEqual({ year: 2016, day: 1 });
+      expect(getPresentDate()).toEqual({ year: 2016, day: 1 });
     });
     it('Christmas Eve', () => {
       jest.setSystemTime(new Date(Date.UTC(2016, 11, 25, 4)));
-      expect(presentDate()).toEqual({ year: 2016, day: 24 });
+      expect(getPresentDate()).toEqual({ year: 2016, day: 24 });
     });
     it('Christmas Day', () => {
       jest.setSystemTime(new Date(Date.UTC(2016, 11, 25, 5)));
-      expect(presentDate()).toEqual({ year: 2016, day: 25 });
+      expect(getPresentDate()).toEqual({ year: 2016, day: 25 });
     });
     it("New Year's Eve", () => {
       jest.setSystemTime(new Date(Date.UTC(2017, 0)));
-      expect(presentDate()).toEqual({ year: 2016, day: 25 });
+      expect(getPresentDate()).toEqual({ year: 2016, day: 25 });
     });
   });
+});
 
-  describe('Verify behavior of date calculation', () => {
-    it('getPresentDate() initializes once', () => {
-      jest.setSystemTime(new Date(Date.UTC(2016, 0)));
-      const presentDate = getPresentDate();
-      jest.setSystemTime(new Date(Date.UTC(2017, 0)));
-      expect(getPresentDate()).toEqual(presentDate);
-    });
+describe('timeRemaining', () => {
+  beforeAll(() => jest.useFakeTimers());
+  afterAll(() => jest.useRealTimers());
+
+  it('UTC same date', () => {
+    jest.setSystemTime(new Date(Date.UTC(2016, 11, 1, 3, 59, 27, 400)));
+    expect(timeUntilMidnight()).toEqual({ h: 1, m: 0, s: 32, ms: 600 });
+  });
+
+  it('After NY midnight should be negative', () => {
+    jest.setSystemTime(new Date(Date.UTC(2016, 11, 1, 5, 0, 2, 570)));
+    expect(timeUntilMidnight().h).toBeLessThan(0);
+  });
+
+  it('UTC next date', () => {
+    jest.setSystemTime(new Date(Date.UTC(2016, 11, 1, 20, 30, 0, 101)));
+    expect(timeUntilMidnight()).toEqual({ h: 8, m: 29, s: 59, ms: 899 });
   });
 });
 

--- a/libs/shared/util/date/src/lib/date.ts
+++ b/libs/shared/util/date/src/lib/date.ts
@@ -7,7 +7,7 @@ const dateFormat = new Intl.DateTimeFormat('en-US', {
   timeZoneName: 'short',
 });
 
-export const presentDate = () => {
+export const getPresentDate = (): CalendarDay => {
   const [month, day, year] = dateFormat
     .format(new Date())
     .split(/\/|,.*$/gi)
@@ -17,19 +17,28 @@ export const presentDate = () => {
     case 12:
       return { year, day: Math.min(day, 25) };
     case 11:
-      return { year, day: 0 };
+      return { year, day: day - 30 };
     default:
       return { year: year - 1, day: 25 };
   }
 };
 
-const date: CalendarDay = presentDate();
-
-export const getPresentDate = (): CalendarDay => {
-  return { ...date };
+export const timeUntilMidnight = (): { h: number; m: number; s: number; ms: number } => {
+  // JS Date is iffy with timezones besides browser's local time and UTC, so we use UTC.
+  const now = new Date();
+  const midnight = new Date(now.getTime());
+  midnight.getUTCHours() >= 17 && midnight.setUTCDate(midnight.getUTCDate() + 1);
+  midnight.setUTCHours(5, 0, 0, 0);
+  const time = midnight.getTime() - now.getTime();
+  return {
+    h: Math.floor(time / (1000 * 60 * 60)),
+    m: Math.floor(time / (1000 * 60)) % 60,
+    s: Math.floor(time / 1000) % 60,
+    ms: time % 1000,
+  };
 };
 
 export const hasDateOccured = ({ year: testYear, day: testDay }: CalendarDay) => {
-  const { day, year } = presentDate();
+  const { day, year } = getPresentDate();
   return testYear < year || (testYear === year && testDay <= day);
 };


### PR DESCRIPTION
Added a countdown to each puzzle that starts 12h before the puzzle unlocks. The puzzle can now also be opened without needing to refresh the page.

Using the new timer requires rebuilding `react-app`.